### PR TITLE
Add SaaS skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ If Pomodor adds any value to your life, you might consider [donation][donate]. B
 
 Feel free to create pull requests and open some issues.
 
+## SaaS and Monetization
+
+This fork adds basic SaaS capabilities. Users can now sign in using email or Google accounts, upgrade to a Pro plan and unlock features such as data export. Subscription status is stored locally but can be extended to any backend or payment provider like Stripe for real monetization.
+
 [image 1]: screenshots/1.svg?raw=true&sanitize=true
 [image 2]: screenshots/2.svg?raw=true&sanitize=true
 [image 3]: screenshots/3.svg?raw=true&sanitize=true

--- a/src/App.js
+++ b/src/App.js
@@ -12,6 +12,7 @@ import { ThemeConfig } from './ThemeConfig'
 import { startSetLabels } from './data/labels/actions'
 import { startSetSessions } from './data/sessions/actions'
 import { setProgressVisibility } from './data/progress/actions'
+import { startLoadSubscription } from './data/subscription/actions'
 
 const App = () => {
   const dispatch = useDispatch()
@@ -35,6 +36,7 @@ const App = () => {
           dispatch(startSetSettings()),
           dispatch(startSetLabels()),
           dispatch(startSetSessions()),
+          dispatch(startLoadSubscription()),
         ])
 
         dispatch(setProgressVisibility(false))

--- a/src/data/subscription/actions.js
+++ b/src/data/subscription/actions.js
@@ -1,0 +1,14 @@
+export const setSubscription = (plan) => ({
+  type: 'SET_SUBSCRIPTION',
+  plan,
+})
+
+export const startLoadSubscription = () => (dispatch) => {
+  const plan = localStorage.getItem('subscription') || 'free'
+  dispatch(setSubscription(plan))
+}
+
+export const startSetSubscription = (plan) => (dispatch) => {
+  localStorage.setItem('subscription', plan)
+  dispatch(setSubscription(plan))
+}

--- a/src/data/subscription/reducer.js
+++ b/src/data/subscription/reducer.js
@@ -1,0 +1,12 @@
+export const initialState = {
+  plan: 'free',
+}
+
+export const reducer = (state = initialState, action) => {
+  switch (action.type) {
+    case 'SET_SUBSCRIPTION':
+      return { ...state, plan: action.plan }
+    default:
+      return state
+  }
+}

--- a/src/layout/MainContainer.js
+++ b/src/layout/MainContainer.js
@@ -9,6 +9,8 @@ import MatLinearProgress from '@material-ui/core/LinearProgress'
 import { Timer } from '../scenes/Timer/Timer'
 import { Stats } from '../scenes/Stats/Stats'
 import { Settings } from '../scenes/Settings/Settings'
+import { Upgrade } from '../scenes/Upgrade/Upgrade'
+import { Export } from '../scenes/Export/Export'
 import { ScrollToTop } from './navigation/ScrollToTop'
 import { Page404 } from '../Page404'
 import { Footer } from './footer/Footer'
@@ -34,6 +36,8 @@ export const MainContainer = () => {
             <Route path="/timer" component={Timer} />
             <Route path="/stats" component={Stats} />
             <Route path="/settings" component={Settings} />
+            <Route path="/upgrade" component={Upgrade} />
+            <Route path="/export" component={Export} />
             <Route component={Page404} />
           </Switch>
         </Box>

--- a/src/layout/navigation/NavList.js
+++ b/src/layout/navigation/NavList.js
@@ -10,6 +10,7 @@ import ListItemText from '@material-ui/core/ListItemText'
 import TimerIcon from '@material-ui/icons/Timer'
 import ShowChartIcon from '@material-ui/icons/ShowChart'
 import SettingsIcon from '@material-ui/icons/Settings'
+import CloudDownloadIcon from '@material-ui/icons/CloudDownload'
 import { useTheme } from '@material-ui/core'
 import Tooltip from '@material-ui/core/Tooltip'
 import { STATUSES } from '../../scenes/Timer/data/timer/reducer'
@@ -79,6 +80,15 @@ export const NavList = () => {
           </NavListItem>
         </Link>
       </Tooltip>
+
+      <Link to="/export">
+        <NavListItem button>
+          <NavItemIcon>
+            <CloudDownloadIcon />
+          </NavItemIcon>
+          <ListItemText primary="Export" />
+        </NavListItem>
+      </Link>
     </MatNavList>
   )
 }

--- a/src/layout/navigation/SignIn.js
+++ b/src/layout/navigation/SignIn.js
@@ -11,6 +11,7 @@ import SvgIcon from '@material-ui/core/SvgIcon'
 import { GoogleIcon } from './GoogleIcon'
 import { linkAccount } from '../../data/auth/actions'
 import { googleAuthProvider } from '../../firebase/firebase'
+import { firebase } from '../../firebase/firebase'
 import { setProgressVisibility } from '../../data/progress/actions'
 
 export const SignIn = () => {
@@ -21,6 +22,20 @@ export const SignIn = () => {
     dispatch(setProgressVisibility(true))
     handleClose()
     await dispatch(linkAccount(googleAuthProvider))
+    dispatch(setProgressVisibility(false))
+  }
+
+  const emailAuth = async () => {
+    const email = window.prompt('Email')
+    const password = window.prompt('Password')
+    if (!email || !password) return
+    dispatch(setProgressVisibility(true))
+    handleClose()
+    try {
+      await firebase.auth().signInWithEmailAndPassword(email, password)
+    } catch (e) {
+      await firebase.auth().createUserWithEmailAndPassword(email, password)
+    }
     dispatch(setProgressVisibility(false))
   }
 
@@ -56,6 +71,9 @@ export const SignIn = () => {
             </SvgIcon>
           </ListItemIcon>
           <ListItemText primary="Sign in via Google" />
+        </MenuItem>
+        <MenuItem onClick={emailAuth}>
+          <ListItemText primary="Sign in via Email" />
         </MenuItem>
       </Menu>
     </>

--- a/src/scenes/Export/Export.js
+++ b/src/scenes/Export/Export.js
@@ -1,0 +1,49 @@
+import React from 'react'
+import { useSelector } from 'react-redux'
+import Button from '@material-ui/core/Button'
+import Typography from '@material-ui/core/Typography'
+
+export const Export = () => {
+  const sessions = useSelector((state) => state.sessions)
+  const plan = useSelector((state) => state.subscription.plan)
+
+  const exportCsv = () => {
+    const rows = [
+      ['id', 'duration', 'label', 'createdAt'],
+      ...sessions.map((s) => [s.id, s.duration, s.label || '', s.createdAt]),
+    ]
+    const csvContent = rows.map((r) => r.join(',')).join('\n')
+    const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' })
+    const url = URL.createObjectURL(blob)
+    const link = document.createElement('a')
+    link.href = url
+    link.setAttribute('download', 'sessions.csv')
+    document.body.appendChild(link)
+    link.click()
+    document.body.removeChild(link)
+  }
+
+  if (plan !== 'pro') {
+    return (
+      <div style={{ padding: 16 }}>
+        <Typography variant="h6" gutterBottom>
+          Export is a Pro feature
+        </Typography>
+        <Button variant="contained" color="secondary" href="/upgrade">
+          Upgrade to Pro
+        </Button>
+      </div>
+    )
+  }
+
+  return (
+    <div style={{ padding: 16 }}>
+      <Typography variant="h6" gutterBottom>
+        Export your sessions
+      </Typography>
+      <Button variant="contained" color="primary" onClick={exportCsv}>
+        Download CSV
+      </Button>
+    </div>
+  )
+}

--- a/src/scenes/Upgrade/Upgrade.js
+++ b/src/scenes/Upgrade/Upgrade.js
@@ -1,0 +1,28 @@
+import React from 'react'
+import { useDispatch } from 'react-redux'
+import Button from '@material-ui/core/Button'
+import Typography from '@material-ui/core/Typography'
+import { startSetSubscription } from '../../data/subscription/actions'
+
+export const Upgrade = () => {
+  const dispatch = useDispatch()
+
+  const upgrade = () => {
+    // Placeholder for payment integration
+    dispatch(startSetSubscription('pro'))
+  }
+
+  return (
+    <div style={{ padding: 16 }}>
+      <Typography variant="h6" gutterBottom>
+        Upgrade to Pro
+      </Typography>
+      <Typography paragraph>
+        Unlock advanced features like exporting your session history and more.
+      </Typography>
+      <Button variant="contained" color="primary" onClick={upgrade}>
+        Upgrade Now
+      </Button>
+    </div>
+  )
+}

--- a/src/store.js
+++ b/src/store.js
@@ -6,6 +6,7 @@ import { reducer as settingsReducer } from './data/settings/reducer'
 import { reducer as labelsReducer } from './data/labels/reducer'
 import { reducer as sessionsReducer } from './data/sessions/reducer'
 import { reducer as progressReducer } from './data/progress/reducer'
+import { reducer as subscriptionReducer } from './data/subscription/reducer'
 import { reducer as timerReducer } from './scenes/Timer/data/timer/reducer'
 
 const appReducer = combineReducers({
@@ -15,6 +16,7 @@ const appReducer = combineReducers({
   timer: timerReducer,
   sessions: sessionsReducer,
   progress: progressReducer,
+  subscription: subscriptionReducer,
 })
 
 const composeEnhancers = composeWithDevTools({ trace: true, traceLimit: 25 })


### PR DESCRIPTION
## Summary
- add subscription state and upgrade page
- add export functionality for Pro users
- allow email login alongside Google
- expose export/upgrade routes and links

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f5e88ce5c8320a2faf017543c51c6