### PR TITLE
Add SessionsTable to Stats page

### DIFF
--- a/src/scenes/Stats/Stats.js
+++ b/src/scenes/Stats/Stats.js
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux'
 import { Overview } from './components/Overview'
 import { DaysChart } from './components/DaysChart'
 import { LabelsChart } from './components/LabelsChart'
+import { SessionsTable } from './components/SessionsTable'
 import { NoData } from './components/NoData'
 import { Grid } from '@material-ui/core'
 import styled from 'styled-components'
@@ -25,6 +26,10 @@ export const Stats = () => {
 
             <Grid item xs={12} lg={6}>
               <LabelsChart />
+            </Grid>
+
+            <Grid item xs={12}>
+              <SessionsTable />
             </Grid>
           </Grid>
         </Container>

--- a/src/scenes/Stats/components/SessionsTable.js
+++ b/src/scenes/Stats/components/SessionsTable.js
@@ -1,0 +1,66 @@
+import React from 'react'
+import { useSelector } from 'react-redux'
+import { useTheme } from '@material-ui/core'
+import {
+  Card as MatCard,
+  CardHeader,
+  CardContent,
+  Table,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableBody,
+} from '@material-ui/core'
+import styled from 'styled-components'
+import dayjs from 'dayjs'
+
+export const SessionsTable = () => {
+  const sessions = useSelector((state) => state.sessions)
+  const labels = useSelector((state) => state.labels.data)
+  const darkMode = useSelector((state) => +state.settings.darkMode)
+  const theme = useTheme()
+
+  const getLabelName = (id) => {
+    const label = labels.find((l) => l.id === id)
+    return label ? label.name : '-'
+  }
+
+  const formatDuration = ({ minutes, seconds }) => {
+    return `${minutes}m ${seconds}s`
+  }
+
+  return (
+    <Card theme={theme} dark={darkMode}>
+      <CardHeader title="Sessions" />
+      <CardContent>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>Date</TableCell>
+              <TableCell>Label</TableCell>
+              <TableCell align="right">Duration</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {sessions.map((session) => (
+              <TableRow key={session.id}>
+                <TableCell>
+                  {dayjs(session.createdAt).format('MMM D, YYYY HH:mm')}
+                </TableCell>
+                <TableCell>{getLabelName(session.label)}</TableCell>
+                <TableCell align="right">
+                  {formatDuration(session.duration)}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  )
+}
+
+const Card = styled(MatCard)`
+  background: ${({ dark }) => (dark ? '#252525' : '#fff')};
+  overflow-x: auto;
+`

--- a/src/scenes/Stats/components/tests/SessionsTable.test.js
+++ b/src/scenes/Stats/components/tests/SessionsTable.test.js
@@ -1,0 +1,37 @@
+import React from 'react'
+import * as redux from 'react-redux'
+import { createShallow } from '@material-ui/core/test-utils'
+import { SessionsTable } from '../SessionsTable'
+import sessions from '../../../../data/sessions/tests/mock-data/sessions'
+import labels from '../../../../data/labels/tests/mock-data/labels'
+
+describe('<SessionsTable />', () => {
+  const shallow = createShallow()
+  const createWrapper = () => shallow(<SessionsTable />)
+
+  const createStore = () => {
+    const store = {
+      sessions,
+      labels: { data: labels },
+      settings: { darkMode: false },
+    }
+
+    jest.spyOn(redux, 'useSelector').mockImplementation((cb) => cb(store))
+
+    return store
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  test('should render <SessionsTable /> correctly', () => {
+    createStore()
+    expect(createWrapper()).toMatchSnapshot()
+  })
+
+  test('should render all sessions', () => {
+    createStore()
+    expect(createWrapper().find('TableRow').length - 1).toBe(sessions.length)
+  })
+})


### PR DESCRIPTION
## Summary
- add SessionsTable component for listing each session duration
- include SessionsTable in Stats scene
- test SessionsTable component

## Testing
- `npm test -- -u` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f6d780fc4832096fed61b2aa0cc8d