### PR TITLE
Add goal settings and streak tracking

### DIFF
--- a/src/data/settings/actions.js
+++ b/src/data/settings/actions.js
@@ -153,6 +153,40 @@ export const startSetFirstDayOfTheWeek = (firstDayOfTheWeek) => {
   }
 }
 
+export const setDailyGoal = (dailyGoal) => ({
+  type: 'SET_DAILY_GOAL',
+  dailyGoal,
+})
+
+export const startSetDailyGoal = (dailyGoal) => {
+  return async (dispatch, getState) => {
+    const uid = getState().auth.uid
+
+    dispatch(setDailyGoal(dailyGoal))
+
+    await fs
+      .doc(`users/${uid}`)
+      .set({ settings: { dailyGoal } }, { merge: true })
+  }
+}
+
+export const setWeeklyGoal = (weeklyGoal) => ({
+  type: 'SET_WEEKLY_GOAL',
+  weeklyGoal,
+})
+
+export const startSetWeeklyGoal = (weeklyGoal) => {
+  return async (dispatch, getState) => {
+    const uid = getState().auth.uid
+
+    dispatch(setWeeklyGoal(weeklyGoal))
+
+    await fs
+      .doc(`users/${uid}`)
+      .set({ settings: { weeklyGoal } }, { merge: true })
+  }
+}
+
 export const setSettings = (settings) => ({
   type: 'SET_SETTINGS',
   settings,

--- a/src/data/settings/reducer.js
+++ b/src/data/settings/reducer.js
@@ -8,6 +8,8 @@ export const initialState = {
   darkMode: false,
   autostart: false,
   firstDayOfTheWeek: 'Monday',
+  dailyGoal: { type: 'pomodoros', value: 4 },
+  weeklyGoal: { type: 'pomodoros', value: 20 },
 }
 
 export const reducer = (state = initialState, action) => {
@@ -56,6 +58,16 @@ export const reducer = (state = initialState, action) => {
       return {
         ...state,
         firstDayOfTheWeek: action.firstDayOfTheWeek,
+      }
+    case 'SET_DAILY_GOAL':
+      return {
+        ...state,
+        dailyGoal: action.dailyGoal,
+      }
+    case 'SET_WEEKLY_GOAL':
+      return {
+        ...state,
+        weeklyGoal: action.weeklyGoal,
       }
     case 'SET_SETTINGS':
       return {

--- a/src/scenes/Settings/Settings.js
+++ b/src/scenes/Settings/Settings.js
@@ -4,6 +4,7 @@ import useMediaQuery from '@material-ui/core/useMediaQuery'
 import { Sliders } from './components/Sliders'
 import { Switches } from './components/Switches'
 import { DaySelect } from './components/DaySelect'
+import { Goals } from './components/Goals'
 
 export const Settings = () => {
   const sidenav = +useMediaQuery('(min-width:600px) and (min-height:500px)')
@@ -12,6 +13,7 @@ export const Settings = () => {
     <Container sidenav={sidenav}>
       <Sliders />
       <DaySelect />
+      <Goals />
       <Switches />
     </Container>
   )

--- a/src/scenes/Settings/components/Goals.js
+++ b/src/scenes/Settings/components/Goals.js
@@ -1,0 +1,122 @@
+import React, { useEffect, useState } from 'react'
+import { useSelector, useDispatch } from 'react-redux'
+import Box from '@material-ui/core/Box'
+import MatFormControl from '@material-ui/core/FormControl'
+import InputLabel from '@material-ui/core/InputLabel'
+import Select from '@material-ui/core/Select'
+import MenuItem from '@material-ui/core/MenuItem'
+import TextField from '@material-ui/core/TextField'
+import styled, { css } from 'styled-components'
+import { startSetDailyGoal, startSetWeeklyGoal } from '../../../data/settings/actions'
+import { useTheme } from '@material-ui/core'
+
+export const Goals = () => {
+  const { dailyGoal, weeklyGoal, darkMode } = useSelector((state) => state.settings)
+  const dispatch = useDispatch()
+
+  const [dailyType, setDailyType] = useState('pomodoros')
+  const [dailyValue, setDailyValue] = useState(0)
+  const [weeklyType, setWeeklyType] = useState('pomodoros')
+  const [weeklyValue, setWeeklyValue] = useState(0)
+
+  useEffect(() => {
+    if (dailyGoal) {
+      setDailyType(dailyGoal.type)
+      setDailyValue(dailyGoal.value)
+    }
+  }, [dailyGoal])
+
+  useEffect(() => {
+    if (weeklyGoal) {
+      setWeeklyType(weeklyGoal.type)
+      setWeeklyValue(weeklyGoal.value)
+    }
+  }, [weeklyGoal])
+
+  const handleDailyValueBlur = () => {
+    dispatch(startSetDailyGoal({ type: dailyType, value: Number(dailyValue) }))
+  }
+
+  const handleWeeklyValueBlur = () => {
+    dispatch(startSetWeeklyGoal({ type: weeklyType, value: Number(weeklyValue) }))
+  }
+
+  const theme = useTheme()
+  const dark = +darkMode
+
+  return (
+    <div>
+      <Box my={2}>
+        <GoalFormControl variant="outlined" dark={dark} theme={theme}>
+          <InputLabel id="daily-goal-type">Daily Goal</InputLabel>
+          <Select
+            labelId="daily-goal-type"
+            value={dailyType}
+            onChange={(e) => {
+              setDailyType(e.target.value)
+              dispatch(startSetDailyGoal({ type: e.target.value, value: Number(dailyValue) }))
+            }}
+            label="Daily Goal"
+          >
+            <MenuItem value="pomodoros">Pomodoros</MenuItem>
+            <MenuItem value="minutes">Minutes</MenuItem>
+          </Select>
+        </GoalFormControl>
+        <TextField
+          type="number"
+          variant="outlined"
+          value={dailyValue}
+          onChange={(e) => setDailyValue(e.target.value)}
+          onBlur={handleDailyValueBlur}
+          label="Value"
+          fullWidth
+          margin="dense"
+        />
+      </Box>
+
+      <Box my={2}>
+        <GoalFormControl variant="outlined" dark={dark} theme={theme}>
+          <InputLabel id="weekly-goal-type">Weekly Goal</InputLabel>
+          <Select
+            labelId="weekly-goal-type"
+            value={weeklyType}
+            onChange={(e) => {
+              setWeeklyType(e.target.value)
+              dispatch(startSetWeeklyGoal({ type: e.target.value, value: Number(weeklyValue) }))
+            }}
+            label="Weekly Goal"
+          >
+            <MenuItem value="pomodoros">Pomodoros</MenuItem>
+            <MenuItem value="minutes">Minutes</MenuItem>
+          </Select>
+        </GoalFormControl>
+        <TextField
+          type="number"
+          variant="outlined"
+          value={weeklyValue}
+          onChange={(e) => setWeeklyValue(e.target.value)}
+          onBlur={handleWeeklyValueBlur}
+          label="Value"
+          fullWidth
+          margin="dense"
+        />
+      </Box>
+    </div>
+  )
+}
+
+const GoalFormControl = styled(MatFormControl)`
+  width: 100%;
+
+  ${({ dark, theme }) =>
+    dark &&
+    css`
+      .MuiFormLabel-root.Mui-focused {
+        color: ${theme.palette.primary.light};
+      }
+
+      .MuiOutlinedInput-root.Mui-focused .MuiOutlinedInput-notchedOutline {
+        border-color: ${theme.palette.primary.light};
+      }
+    `}
+`

--- a/src/scenes/Stats/Stats.js
+++ b/src/scenes/Stats/Stats.js
@@ -4,6 +4,7 @@ import { Overview } from './components/Overview'
 import { DaysChart } from './components/DaysChart'
 import { LabelsChart } from './components/LabelsChart'
 import { NoData } from './components/NoData'
+import { GoalStreak } from './components/GoalStreak'
 import { Grid } from '@material-ui/core'
 import styled from 'styled-components'
 
@@ -15,9 +16,13 @@ export const Stats = () => {
       {sessions && sessions.length ? (
         <Container>
           <Grid container spacing={5} justify="center">
-            <Grid item xs={12}>
-              <Overview />
-            </Grid>
+          <Grid item xs={12}>
+            <Overview />
+          </Grid>
+
+          <Grid item xs={12}>
+            <GoalStreak />
+          </Grid>
 
             <Grid item xs={12} lg={6}>
               <DaysChart />

--- a/src/scenes/Stats/components/GoalStreak.js
+++ b/src/scenes/Stats/components/GoalStreak.js
@@ -1,0 +1,66 @@
+import React from 'react'
+import { useSelector } from 'react-redux'
+import styled from 'styled-components'
+import MatCard from '@material-ui/core/Card'
+import CardHeader from '@material-ui/core/CardHeader'
+import MatCardContent from '@material-ui/core/CardContent'
+import Box from '@material-ui/core/Box'
+import dayjs from 'dayjs'
+
+export const GoalStreak = () => {
+  const sessions = useSelector((state) => state.sessions)
+  const { dailyGoal, weeklyGoal } = useSelector((state) => state.settings)
+
+  if (!dailyGoal || !weeklyGoal) return null
+
+  const getValue = (list, type) =>
+    type === 'minutes'
+      ? list.reduce((sum, s) => sum + s.duration.minutes, 0)
+      : list.length
+
+  const todaySessions = sessions.filter((s) =>
+    dayjs(s.createdAt).isSame(dayjs(), 'day')
+  )
+  const weekSessions = sessions.filter((s) =>
+    dayjs(s.createdAt).isAfter(dayjs().subtract(7, 'day'))
+  )
+
+  const dailyProgress = getValue(todaySessions, dailyGoal.type)
+  const weeklyProgress = getValue(weekSessions, weeklyGoal.type)
+
+  const calcStreak = () => {
+    let streak = 0
+    let day = dayjs()
+    while (true) {
+      const daySessions = sessions.filter((s) =>
+        dayjs(s.createdAt).isSame(day, 'day')
+      )
+      const progress = getValue(daySessions, dailyGoal.type)
+      if (progress >= dailyGoal.value && daySessions.length) {
+        streak += 1
+        day = day.subtract(1, 'day')
+      } else {
+        break
+      }
+    }
+    return streak
+  }
+
+  const streak = calcStreak()
+
+  return (
+    <Card>
+      <CardHeader title="Goals & Streak" />
+      <CardContent>
+        <Box mb={1}>Daily: {dailyProgress}/{dailyGoal.value}{' '}
+        {dailyGoal.type === 'minutes' ? 'min' : 'sessions'}</Box>
+        <Box mb={1}>Weekly: {weeklyProgress}/{weeklyGoal.value}{' '}
+        {weeklyGoal.type === 'minutes' ? 'min' : 'sessions'}</Box>
+        <Box>Current streak: {streak} days</Box>
+      </CardContent>
+    </Card>
+  )
+}
+
+const Card = styled(MatCard)``
+const CardContent = styled(MatCardContent)``

--- a/src/scenes/Timer/Timer.js
+++ b/src/scenes/Timer/Timer.js
@@ -3,6 +3,7 @@ import Box from '@material-ui/core/Box'
 import { CountdownCircle } from './components/CountdownCircle'
 import { ToggleButton } from './components/ToggleButton'
 import { RoundsCounter } from './components/RoundsCounter'
+import { DailyProgress } from './components/DailyProgress'
 import { ResetButton } from './components/ResetButton'
 import { SkipButton } from './components/SkipButton'
 import { FullscreenDialog } from './components/Labels/FullscreenDialog'
@@ -42,6 +43,9 @@ export const Timer = () => {
 
       <Box display="flex" justifyContent="center">
         <RoundsCounter />
+      </Box>
+      <Box display="flex" justifyContent="center">
+        <DailyProgress />
       </Box>
 
       <FullscreenDialog />

--- a/src/scenes/Timer/components/DailyProgress.js
+++ b/src/scenes/Timer/components/DailyProgress.js
@@ -1,0 +1,33 @@
+import React from 'react'
+import { useSelector } from 'react-redux'
+import dayjs from 'dayjs'
+import styled from 'styled-components'
+import { CounterLabel } from './RoundsCounter'
+
+export const DailyProgress = () => {
+  const sessions = useSelector((state) => state.sessions)
+  const { dailyGoal } = useSelector((state) => state.settings)
+
+  if (!dailyGoal) return null
+
+  const todaySessions = sessions.filter((s) =>
+    dayjs(s.createdAt).isSame(dayjs(), 'day')
+  )
+
+  const progress = dailyGoal.type === 'minutes'
+    ? todaySessions.reduce((sum, s) => sum + s.duration.minutes, 0)
+    : todaySessions.length
+
+  const total = dailyGoal.value || 0
+
+  return (
+    <ProgressLabel>
+      {progress}/{total}{' '}
+      {dailyGoal.type === 'minutes' ? 'min' : 'sessions'} today
+    </ProgressLabel>
+  )
+}
+
+const ProgressLabel = styled(CounterLabel)`
+  margin-top: 4px;
+`


### PR DESCRIPTION
## Summary
- add daily/weekly goal options to settings state
- add actions and reducers for saving goals
- enable editing goals in settings
- display daily progress below timer
- show goal and streak progress in stats page

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f6d5d58b483208e17428e62cad88b