### PR TITLE
Add task tracking to Pomodoro sessions

### DIFF
--- a/src/data/sessions/actions.js
+++ b/src/data/sessions/actions.js
@@ -33,7 +33,7 @@ export const addSession = (session) => ({
 export const startAddSession = (session) => {
   return async (dispatch, getState) => {
     const uid = getState().auth.uid
-    const { duration, label = null, createdAt } = session
+    const { duration, label = null, tasks = [], createdAt } = session
 
     const newSessionRef = fs.collection(`users/${uid}/sessions`).doc()
 
@@ -47,6 +47,7 @@ export const startAddSession = (session) => {
     await newSessionRef.set({
       duration,
       label,
+      tasks,
       createdAt,
     })
 

--- a/src/data/sessions/tests/actions.test.js
+++ b/src/data/sessions/tests/actions.test.js
@@ -24,9 +24,9 @@ beforeEach(async (done) => {
     batch.delete(fs.doc(`users/${uid}/sessions/${id}`))
   })
 
-  sessions.forEach(({ id, label, duration, createdAt }) => {
+  sessions.forEach(({ id, label, duration, tasks, createdAt }) => {
     const ref = fs.collection(`users/${uid}/sessions`).doc(id)
-    batch.set(ref, { label, duration, createdAt })
+    batch.set(ref, { label, duration, tasks, createdAt })
   })
 
   await batch.commit()

--- a/src/data/sessions/tests/mock-data/sessions.js
+++ b/src/data/sessions/tests/mock-data/sessions.js
@@ -3,18 +3,24 @@ export default [
     id: '1',
     label: 'Study',
     duration: { seconds: 0, minutes: 25 },
+    tasks: [
+      { id: 't1', text: 'Read', completed: true },
+      { id: 't2', text: 'Write', completed: false },
+    ],
     createdAt: 1586815200000,
   },
   {
     id: '2',
     label: 'Play the guitar',
     duration: { seconds: 0, minutes: 25 },
+    tasks: [{ id: 't3', text: 'Practice chords', completed: false }],
     createdAt: 1586901600000,
   },
   {
     id: '3',
     label: 'Clean the room',
     duration: { seconds: 0, minutes: 25 },
+    tasks: [],
     createdAt: 1585778400000,
   },
 ]

--- a/src/data/tasks/actions.js
+++ b/src/data/tasks/actions.js
@@ -1,0 +1,19 @@
+export const addTask = (task) => ({
+  type: 'ADD_TASK',
+  task,
+})
+
+export const editTask = (id, text) => ({
+  type: 'EDIT_TASK',
+  id,
+  text,
+})
+
+export const toggleTask = (id) => ({
+  type: 'TOGGLE_TASK',
+  id,
+})
+
+export const clearTasks = () => ({
+  type: 'CLEAR_TASKS',
+})

--- a/src/data/tasks/reducer.js
+++ b/src/data/tasks/reducer.js
@@ -1,0 +1,20 @@
+export const initialState = []
+
+export const reducer = (state = initialState, action) => {
+  switch (action.type) {
+    case 'ADD_TASK':
+      return [...state, action.task]
+    case 'EDIT_TASK':
+      return state.map((t) =>
+        t.id === action.id ? { ...t, text: action.text } : t
+      )
+    case 'TOGGLE_TASK':
+      return state.map((t) =>
+        t.id === action.id ? { ...t, completed: !t.completed } : t
+      )
+    case 'CLEAR_TASKS':
+      return []
+    default:
+      return state
+  }
+}

--- a/src/data/tasks/tests/actions.test.js
+++ b/src/data/tasks/tests/actions.test.js
@@ -1,0 +1,23 @@
+import { addTask, editTask, toggleTask, clearTasks } from '../actions'
+
+const task = { id: '1', text: 'Task', completed: false }
+
+test('should create addTask action', () => {
+  expect(addTask(task)).toEqual({ type: 'ADD_TASK', task })
+})
+
+test('should create editTask action', () => {
+  expect(editTask('1', 'New')).toEqual({
+    type: 'EDIT_TASK',
+    id: '1',
+    text: 'New',
+  })
+})
+
+test('should create toggleTask action', () => {
+  expect(toggleTask('1')).toEqual({ type: 'TOGGLE_TASK', id: '1' })
+})
+
+test('should create clearTasks action', () => {
+  expect(clearTasks()).toEqual({ type: 'CLEAR_TASKS' })
+})

--- a/src/data/tasks/tests/reducer.test.js
+++ b/src/data/tasks/tests/reducer.test.js
@@ -1,0 +1,28 @@
+import { reducer, initialState } from '../reducer'
+
+const sample = { id: '1', text: 'Task', completed: false }
+
+test('should setup default tasks state', () => {
+  const state = reducer(undefined, { type: '@@INIT' })
+  expect(state).toEqual(initialState)
+})
+
+test('should add task', () => {
+  const state = reducer(initialState, { type: 'ADD_TASK', task: sample })
+  expect(state).toEqual([sample])
+})
+
+test('should edit task', () => {
+  const state = reducer([sample], { type: 'EDIT_TASK', id: '1', text: 'New' })
+  expect(state[0].text).toBe('New')
+})
+
+test('should toggle task', () => {
+  const state = reducer([sample], { type: 'TOGGLE_TASK', id: '1' })
+  expect(state[0].completed).toBe(true)
+})
+
+test('should clear tasks', () => {
+  const state = reducer([sample], { type: 'CLEAR_TASKS' })
+  expect(state).toEqual([])
+})

--- a/src/scenes/Stats/Stats.js
+++ b/src/scenes/Stats/Stats.js
@@ -6,6 +6,7 @@ import { LabelsChart } from './components/LabelsChart'
 import { NoData } from './components/NoData'
 import { Grid } from '@material-ui/core'
 import styled from 'styled-components'
+import { SessionTasks } from './components/SessionTasks'
 
 export const Stats = () => {
   const sessions = useSelector((state) => state.sessions)
@@ -27,6 +28,7 @@ export const Stats = () => {
               <LabelsChart />
             </Grid>
           </Grid>
+          <SessionTasks />
         </Container>
       ) : (
         <NoData />

--- a/src/scenes/Stats/components/SessionTasks.js
+++ b/src/scenes/Stats/components/SessionTasks.js
@@ -1,0 +1,36 @@
+import React from 'react'
+import { useSelector } from 'react-redux'
+import Box from '@material-ui/core/Box'
+import Typography from '@material-ui/core/Typography'
+import Checkbox from '@material-ui/core/Checkbox'
+import List from '@material-ui/core/List'
+import ListItem from '@material-ui/core/ListItem'
+import ListItemText from '@material-ui/core/ListItemText'
+
+export const SessionTasks = () => {
+  const sessions = useSelector((state) => state.sessions)
+  if (!sessions || !sessions.length) return null
+
+  return (
+    <Box mt={4}>
+      <Typography variant="h6">Tasks</Typography>
+      {sessions.map((s) => (
+        <Box key={s.id} my={2}>
+          <Typography variant="subtitle2">
+            {new Date(s.createdAt).toLocaleString()}
+          </Typography>
+          {s.tasks && s.tasks.length > 0 && (
+            <List dense>
+              {s.tasks.map((t) => (
+                <ListItem key={t.id}>
+                  <Checkbox checked={t.completed} disabled />
+                  <ListItemText primary={t.text} />
+                </ListItem>
+              ))}
+            </List>
+          )}
+        </Box>
+      ))}
+    </Box>
+  )
+}

--- a/src/scenes/Timer/Timer.js
+++ b/src/scenes/Timer/Timer.js
@@ -8,6 +8,7 @@ import { SkipButton } from './components/SkipButton'
 import { FullscreenDialog } from './components/Labels/FullscreenDialog'
 import { DesktopDialog } from './components/Labels/DesktopDialog'
 import { LabelButton } from './components/Labels/LabelButton'
+import { Tasks } from './components/Tasks'
 import { useMediaQuery, useTheme } from '@material-ui/core'
 
 export const Timer = () => {
@@ -29,6 +30,7 @@ export const Timer = () => {
     <Box width={getCircleSize()} m="auto">
       <LabelButton />
       <CountdownCircle />
+      <Tasks />
 
       <Box display="flex" justifyContent="center" alignItems="center" my={3}>
         <ResetButton />

--- a/src/scenes/Timer/components/ResetButton.js
+++ b/src/scenes/Timer/components/ResetButton.js
@@ -6,6 +6,7 @@ import { useDispatch, useSelector } from 'react-redux'
 import { resetTimer, setSaveSessionAlert } from '../data/timer/actions'
 import { TYPES, STATUSES } from '../data/timer/reducer'
 import { SaveSessionAlert } from './SaveSessionAlert'
+import { clearTasks } from '../../../data/tasks/actions'
 
 export const ResetButton = () => {
   const { type, timeLeft, status } = useSelector((state) => state.timer)
@@ -55,6 +56,7 @@ export const ResetButton = () => {
         break
     }
     dispatch(resetTimer({ duration, showTimerInTitle }))
+    dispatch(clearTasks())
   }
 
   return (

--- a/src/scenes/Timer/components/SaveSessionAlert.js
+++ b/src/scenes/Timer/components/SaveSessionAlert.js
@@ -10,6 +10,7 @@ import DialogActions from '@material-ui/core/DialogActions'
 import Button from '@material-ui/core/Button'
 import { setSaveSessionAlert } from '../data/timer/actions'
 import { startAddSession } from '../../../data/sessions/actions'
+import { clearTasks } from '../../../data/tasks/actions'
 
 const Time = styled.span`
   color: ${({ color }) => color};
@@ -18,6 +19,7 @@ const Time = styled.span`
 export const SaveSessionAlert = ({ time }) => {
   const { saveSessionAlert } = useSelector((state) => state.timer)
   const label = useSelector((state) => state.labels.labelSelected)
+  const tasks = useSelector((state) => state.tasks)
 
   const theme = useTheme()
 
@@ -32,9 +34,11 @@ export const SaveSessionAlert = ({ time }) => {
       startAddSession({
         duration: time,
         label: label ? label.id : null,
+        tasks,
         createdAt: Date.now(),
       })
     )
+    dispatch(clearTasks())
     closeAlert()
   }
 

--- a/src/scenes/Timer/components/SkipButton.js
+++ b/src/scenes/Timer/components/SkipButton.js
@@ -4,6 +4,7 @@ import IconButton from '@material-ui/core/IconButton'
 import SkipNext from '@material-ui/icons/SkipNext'
 import { useDispatch, useSelector } from 'react-redux'
 import { setNextTimer } from '../data/timer/actions'
+import { clearTasks } from '../../../data/tasks/actions'
 
 export const SkipButton = () => {
   const { timeLeft } = useSelector((state) => state.timer)
@@ -14,7 +15,10 @@ export const SkipButton = () => {
     <ActionIcon
       disabled={!timeLeft}
       aria-label="Skip current timer"
-      onClick={() => dispatch(setNextTimer(settings))}
+      onClick={() => {
+        dispatch(setNextTimer(settings))
+        dispatch(clearTasks())
+      }}
       size="small"
     >
       <SkipNext />

--- a/src/scenes/Timer/components/Tasks.js
+++ b/src/scenes/Timer/components/Tasks.js
@@ -1,0 +1,65 @@
+import React, { useState } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import Box from '@material-ui/core/Box'
+import TextField from '@material-ui/core/TextField'
+import Checkbox from '@material-ui/core/Checkbox'
+import IconButton from '@material-ui/core/IconButton'
+import AddIcon from '@material-ui/icons/Add'
+import { addTask, editTask, toggleTask } from '../../data/tasks/actions'
+import { TYPES } from '../data/timer/reducer'
+
+export const Tasks = () => {
+  const { type } = useSelector((state) => state.timer)
+  const tasks = useSelector((state) => state.tasks)
+  const dispatch = useDispatch()
+  const [value, setValue] = useState('')
+
+  if (type !== TYPES.work) return null
+
+  const onAdd = (e) => {
+    e.preventDefault()
+    const text = value.trim()
+    if (!text || tasks.length >= 5) return
+    dispatch(addTask({ id: Date.now().toString(), text, completed: false }))
+    setValue('')
+  }
+
+  return (
+    <Box mt={2}>
+      <form onSubmit={onAdd}>
+        <Box display="flex" alignItems="center">
+          <TextField
+            variant="outlined"
+            size="small"
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            placeholder="Add task"
+            fullWidth
+          />
+          <IconButton
+            type="submit"
+            aria-label="add task"
+            disabled={tasks.length >= 5}
+          >
+            <AddIcon />
+          </IconButton>
+        </Box>
+      </form>
+      {tasks.map((task) => (
+        <Box key={task.id} display="flex" alignItems="center" mt={1}>
+          <Checkbox
+            checked={task.completed}
+            onChange={() => dispatch(toggleTask(task.id))}
+            color="primary"
+          />
+          <TextField
+            value={task.text}
+            onChange={(e) => dispatch(editTask(task.id, e.target.value))}
+            size="small"
+            fullWidth
+          />
+        </Box>
+      ))}
+    </Box>
+  )
+}

--- a/src/scenes/Timer/components/ToggleButton.js
+++ b/src/scenes/Timer/components/ToggleButton.js
@@ -20,6 +20,7 @@ import work from '../assets/work.png'
 import alarm from '../assets/alarm.png'
 import coffee from '../assets/coffee.png'
 import { startAddSession } from '../../../data/sessions/actions'
+import { clearTasks } from '../../../data/tasks/actions'
 import useMounted from '../../../helpers/useMounted'
 
 export const ToggleButton = () => {
@@ -30,6 +31,7 @@ export const ToggleButton = () => {
   const darkModeCached = +JSON.parse(localStorage.getItem('darkMode'))
 
   const label = useSelector((state) => state.labels.labelSelected)
+  const tasks = useSelector((state) => state.tasks)
 
   const dispatch = useDispatch()
 
@@ -67,9 +69,11 @@ export const ToggleButton = () => {
             startAddSession({
               label: label ? label.id : null,
               duration: { minutes: settings.workDuration, seconds: 0 },
+              tasks,
               createdAt: Date.now(),
             })
           )
+          dispatch(clearTasks())
         }
 
         setTimeout(async () => {

--- a/src/scenes/Timer/components/tests/SaveSessionAlert.test.js
+++ b/src/scenes/Timer/components/tests/SaveSessionAlert.test.js
@@ -6,6 +6,7 @@ import Button from '@material-ui/core/Button'
 import { SaveSessionAlert } from '../SaveSessionAlert'
 import * as timerActions from '../../data/timer/actions'
 import * as sessionsActions from '../../../../data/sessions/actions'
+import * as tasksActions from '../../../../data/tasks/actions'
 
 describe('<SaveSessionAlert />', () => {
   const time = { minutes: 4, seconds: 11 }
@@ -21,6 +22,7 @@ describe('<SaveSessionAlert />', () => {
     const store = {
       timer: { saveSessionAlert: true },
       labels: { labelSelected: null },
+      tasks: [{ id: '1', text: 'task', completed: false }],
     }
 
     jest
@@ -63,6 +65,9 @@ describe('<SaveSessionAlert />', () => {
     const startAddSessionMocked = jest
       .spyOn(sessionsActions, 'startAddSession')
       .mockImplementation(() => jest.fn())
+    const clearTasksMocked = jest
+      .spyOn(tasksActions, 'clearTasks')
+      .mockImplementation(() => jest.fn())
 
     createStore()
 
@@ -71,7 +76,9 @@ describe('<SaveSessionAlert />', () => {
     expect(startAddSessionMocked).toHaveBeenCalledWith({
       duration: time,
       label: null,
+      tasks: [{ id: '1', text: 'task', completed: false }],
       createdAt: expect.any(Number),
     })
+    expect(clearTasksMocked).toHaveBeenCalled()
   })
 })

--- a/src/store.js
+++ b/src/store.js
@@ -7,6 +7,7 @@ import { reducer as labelsReducer } from './data/labels/reducer'
 import { reducer as sessionsReducer } from './data/sessions/reducer'
 import { reducer as progressReducer } from './data/progress/reducer'
 import { reducer as subscriptionReducer } from './data/subscription/reducer'
+import { reducer as tasksReducer } from './data/tasks/reducer'
 import { reducer as timerReducer } from './scenes/Timer/data/timer/reducer'
 
 const appReducer = combineReducers({
@@ -14,6 +15,7 @@ const appReducer = combineReducers({
   settings: settingsReducer,
   labels: labelsReducer,
   timer: timerReducer,
+  tasks: tasksReducer,
   sessions: sessionsReducer,
   progress: progressReducer,
   subscription: subscriptionReducer,


### PR DESCRIPTION
## Summary
- manage tasks for each session with new redux module
- capture tasks when saving or auto-completing a session
- clear tasks on reset or skip and between sessions
- show tasks list on timer screen and in stats
- update tests for task support

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f6d50bf2083209280d2a370f14bfc